### PR TITLE
Some settings improvements

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,11 @@ This file lists people who made contributions to the project. The exact contribu
 ## Development and maintenance
 The app is currently developed and maintained by [Felix Wiemuth](https://github.com/felixwiemuth/).
 
+### Source code contributions
+The following people have made source code contributions:
+
+- [TacoTheDank](https://github.com/TacoTheDank): maintenance (upgrade and improve code) ([commits](https://github.com/felixwiemuth/SimpleReminder/commits?author=TacoTheDank), [pull requests](https://github.com/felixwiemuth/SimpleReminder/pulls?q=is%3Apr+author%3ATacoTheDank+))
+
 ## Ideas
 The following people contributed ideas and inspiration:
 - Nick Faulwetter

--- a/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsActivity.java
+++ b/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsActivity.java
@@ -20,15 +20,18 @@ package felixwiemuth.simplereminder.ui;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 
+import felixwiemuth.simplereminder.R;
+
 public class SettingsActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
 
         getSupportFragmentManager()
                 .beginTransaction()
-                .replace(android.R.id.content, new SettingsFragment())
+                .replace(R.id.settings_container, new SettingsFragment())
                 .commit();
     }
 }

--- a/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
+++ b/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
@@ -28,7 +28,7 @@ import androidx.annotation.RequiresApi;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
 
 import felixwiemuth.simplereminder.BootReceiver;
 import felixwiemuth.simplereminder.Prefs;
@@ -42,7 +42,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);
 
-        SwitchPreference runOnBootPref = getPreferenceScreen().findPreference(getString(R.string.prefkey_run_on_boot));
+        SwitchPreferenceCompat runOnBootPref = getPreferenceScreen().findPreference(getString(R.string.prefkey_run_on_boot));
         runOnBootPref.setSummaryOff(UIUtils.makeAlertText(R.string.preference_run_on_boot_summary_off, getContext()));
         runOnBootPref.setSummaryOn(R.string.preference_run_on_boot_summary_on);
 

--- a/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
+++ b/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
@@ -68,6 +68,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
                 startActivity(intent);
                 return true;
             });
+            notificationChannelPreference.setIconSpaceReserved(false);
             notificationsPrefGroup.addPreference(notificationChannelPreference);
         }
     }

--- a/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
+++ b/app/src/main/java/felixwiemuth/simplereminder/ui/SettingsFragment.java
@@ -42,11 +42,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);
 
-        SwitchPreferenceCompat runOnBootPref = getPreferenceScreen().findPreference(getString(R.string.prefkey_run_on_boot));
+        SwitchPreferenceCompat runOnBootPref = findPreference(getString(R.string.prefkey_run_on_boot));
         runOnBootPref.setSummaryOff(UIUtils.makeAlertText(R.string.preference_run_on_boot_summary_off, getContext()));
         runOnBootPref.setSummaryOn(R.string.preference_run_on_boot_summary_on);
 
-        Preference batPref = getPreferenceScreen().findPreference(getString(R.string.prefkey_disable_battery_optimization));
+        Preference batPref = findPreference(getString(R.string.prefkey_disable_battery_optimization));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             updateBatteryPrefDescription(batPref);
         } else {
@@ -55,9 +55,9 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
         // Priority/Sound settings only work for Android < 8
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            PreferenceCategory notificationsPrefGroup = getPreferenceScreen().findPreference(getString(R.string.prefkey_notifications));
-            notificationsPrefGroup.removePreference(getPreferenceScreen().findPreference(getString(R.string.prefkey_priority)));
-            notificationsPrefGroup.removePreference(getPreferenceScreen().findPreference(getString(R.string.prefkey_enable_sound)));
+            PreferenceCategory notificationsPrefGroup = findPreference(getString(R.string.prefkey_notifications));
+            notificationsPrefGroup.removePreference(findPreference(getString(R.string.prefkey_priority)));
+            notificationsPrefGroup.removePreference(findPreference(getString(R.string.prefkey_enable_sound)));
 
             Preference notificationChannelPreference = new Preference(getContext());
             notificationChannelPreference.setTitle(R.string.preference_notification_channel_settings);
@@ -76,7 +76,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     public void onResume() {
         super.onResume();
         getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
-        Preference batPref = getPreferenceScreen().findPreference(getString(R.string.prefkey_disable_battery_optimization));
+        Preference batPref = findPreference(getString(R.string.prefkey_disable_battery_optimization));
         if (batPref != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { // the second condition should already follow from the first
             updateBatteryPrefDescription(batPref);
         }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2021 Felix Wiemuth
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settings_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -42,13 +42,13 @@
             android:summary="%s"
             android:title="@string/preference_priority" />
 
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/prefkey_enable_sound"
             android:title="@string/preference_enable_sound" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preference_category_app">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/prefkey_run_on_boot"
             android:title="@string/preference_run_on_boot" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -15,20 +15,28 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <!--<PreferenceCategory-->
-    <!--android:title="@string/preference_category_general">-->
-    <!--<ListPreference-->
-    <!--android:key="pref_key_language"-->
-    <!--android:title="@string/preferences_language"-->
-    <!--android:dialogTitle="@string/preferences_language"-->
-    <!--android:entries="@array/settings_language_values"-->
-    <!--android:entryValues="@array/locales"-->
-    <!--android:defaultValue="@string/system_locale"-->
-    <!--android:summary="%s">-->
-    <!--</ListPreference>-->
-    <!--</PreferenceCategory>-->
-    <PreferenceCategory android:key="@string/prefkey_notifications" android:title="@string/preference_category_notifications">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!--PreferenceCategory
+        android:title="@string/preference_category_general"
+        app:iconSpaceReserved="false">
+
+        <ListPreference
+            android:defaultValue="@string/system_locale"
+            android:dialogTitle="@string/preferences_language"
+            android:entries="@array/settings_language_values"
+            android:entryValues="@array/locales"
+            android:key="pref_key_language"
+            android:summary="%s"
+            android:title="@string/preferences_language"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory-->
+
+    <PreferenceCategory
+        android:key="@string/prefkey_notifications"
+        android:title="@string/preference_category_notifications"
+        app:iconSpaceReserved="false">
 
         <!-- NOTE: @null hides buttons to simplify the UI. Users can touch outside the dialog to
              dismiss it. -->
@@ -40,21 +48,28 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:summary="%s"
-            android:title="@string/preference_priority" />
+            android:title="@string/preference_priority"
+            app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/prefkey_enable_sound"
-            android:title="@string/preference_enable_sound" />
+            android:title="@string/preference_enable_sound"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/preference_category_app">
+
+    <PreferenceCategory
+        android:title="@string/preference_category_app"
+        app:iconSpaceReserved="false">
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/prefkey_run_on_boot"
-            android:title="@string/preference_run_on_boot" />
+            android:title="@string/preference_run_on_boot"
+            app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/prefkey_disable_battery_optimization"
-            android:title="@string/preference_disable_battery_optimization" />
+            android:title="@string/preference_disable_battery_optimization"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
-
 </PreferenceScreen>


### PR DESCRIPTION
### 1st commit
- Use SwitchPreferenceCompat (from #8)

### 2nd commit
- Use FragmentContainerView for the settings fragment (go [here](https://developer.android.com/jetpack/androidx/releases/fragment), do Ctrl + F, and put "FragmentContainerView" in the box to see related info and changes, as well as the [reasons for its creation](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0-alpha02))

### 3rd commit
- Remove redundant getPreferenceScreen calls
- Don't reserve icon space for settings without icons (this makes the settings look nicer margin-wise)
